### PR TITLE
UI improvements: headings and titlecase

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "date-fns": "^4.1.0",
         "primeicons": "^7.0.0",
         "primevue": "^4.3.9",
+        "text-title-case": "^1.2.9",
         "vue": "^3.5.18",
         "vue-router": "^4.5.1"
       },
@@ -4955,6 +4956,37 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/text-lower-case": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/text-lower-case/-/text-lower-case-1.2.9.tgz",
+      "integrity": "sha512-53AOnDrhPpiAUQkgY1SHleKUXp/u7GsqRX13NcCREZscmtjLLJ099uxMRjkK7q2KwHkFYVPl9ytkQlTkTQLS0w==",
+      "license": "MIT"
+    },
+    "node_modules/text-no-case": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/text-no-case/-/text-no-case-1.2.9.tgz",
+      "integrity": "sha512-IcCt328KaapimSrytP4ThfC8URmHZb2DgOqCL9BYvGjpxY2lDiqCkIQk9sClZtwcELs2gTnq83a7jNc573FTLA==",
+      "license": "MIT",
+      "dependencies": {
+        "text-lower-case": "1.2.9"
+      }
+    },
+    "node_modules/text-title-case": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/text-title-case/-/text-title-case-1.2.9.tgz",
+      "integrity": "sha512-RAtC9cdmPp41ns5/HXZBsaQg71BsHT7uZpj2ojTtuFa8o2dNuRYYOrSmy5YdLRIAJQ6WK5hQVpV3jHuq7a+4Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "text-no-case": "1.2.9",
+        "text-upper-case-first": "1.2.9"
+      }
+    },
+    "node_modules/text-upper-case-first": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/text-upper-case-first/-/text-upper-case-first-1.2.9.tgz",
+      "integrity": "sha512-wEDD1B6XqJmEV+xEnBJd+2sBCHZ+7fvA/8Rv/o8+dAsp05YWjYP/kjB8sPH6zqzW0s6jtehIg4IlcKjcYxk2CQ==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "date-fns": "^4.1.0",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.9",
+    "text-title-case": "^1.2.9",
     "vue": "^3.5.18",
     "vue-router": "^4.5.1"
   },

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -16,7 +16,6 @@
   width: 100%;
 }
 .title {
-  font-size: 1.1em;
   font-weight: bold;
   margin-bottom: 10px;
 }

--- a/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
+++ b/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
@@ -3,6 +3,7 @@
     <h2 class="wrapper-center title">Evolution on the selected period</h2>
     <div class="charts">
       <ContentContainer v-for="value in selectedValues" :key="value">
+        <h3 class="chart-heading">{{ value }}</h3>
         <Chart type="line" :data="chartData(value)" :options="chartOptions(value)" />
       </ContentContainer>
     </div>
@@ -93,5 +94,9 @@ const chartData = (value: keyof UserProfileScrapedVec) => {
     width: 36em;
     height: auto;
   }
+}
+
+.chart-heading {
+  text-align: center;
 }
 </style>

--- a/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
+++ b/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
@@ -3,7 +3,7 @@
     <h2 class="wrapper-center title">Evolution on the selected period</h2>
     <div class="charts">
       <ContentContainer v-for="value in selectedValues" :key="value">
-        <h3 class="chart-heading">{{ value }}</h3>
+        <h3 class="chart-heading">{{ titleCase(value) }}</h3>
         <Chart type="line" :data="chartData(value)" :options="chartOptions(value)" />
       </ContentContainer>
     </div>
@@ -13,6 +13,7 @@
 import type { UserProfileVec, UserProfileScrapedVec } from '@/services/api/userStatsService'
 import Chart from 'primevue/chart'
 import ContentContainer from '../ContentContainer.vue'
+import { titleCase } from 'text-title-case'
 import 'chartjs-adapter-date-fns'
 
 const props = defineProps<{

--- a/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
+++ b/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="indexer-stats-detail">
-    <div class="wrapper-center title">Evolution on the selected period</div>
+    <h2 class="wrapper-center title">Evolution on the selected period</h2>
     <div class="charts">
       <ContentContainer v-for="value in selectedValues" :key="value">
         <Chart type="line" :data="chartData(value)" :options="chartOptions(value)" />

--- a/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
+++ b/frontend/src/components/user-stats/IndexerStatsEvolutions.vue
@@ -32,6 +32,11 @@ const chartOptions = (value: keyof UserProfileScrapedVec) => {
       break
   }
   return {
+    plugins: {
+      legend: {
+        display: false,
+      },
+    },
     scales: {
       x: {
         type: 'time',

--- a/frontend/src/components/user-stats/IndexerStatsIncreases.vue
+++ b/frontend/src/components/user-stats/IndexerStatsIncreases.vue
@@ -4,7 +4,7 @@
     <div class="items">
       <ContentContainer v-for="name in selectedValues" :key="name" class="item">
         <span class="value">{{ postProcessStat(name) }}</span>
-        <span class="name">{{ name }}</span>
+        <span class="name">{{ titleCase(name) }}</span>
       </ContentContainer>
     </div>
   </div>
@@ -13,6 +13,7 @@
 import type { UserProfileScrapedVec, UserProfileVec } from '@/services/api/userStatsService'
 import ContentContainer from '../ContentContainer.vue'
 import { bytesToReadable } from '@/services/helpers'
+import { titleCase } from 'text-title-case'
 
 const props = defineProps<{
   userStats: UserProfileVec

--- a/frontend/src/components/user-stats/IndexerStatsIncreases.vue
+++ b/frontend/src/components/user-stats/IndexerStatsIncreases.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="wrapper-center title">Increase on the selected period</div>
+    <h2 class="wrapper-center title">Increase on the selected period</h2>
     <div class="items">
       <ContentContainer v-for="name in selectedValues" :key="name" class="item">
         <span class="value">{{ postProcessStat(name) }}</span>

--- a/frontend/src/components/user-stats/IndexerStatsIncreases.vue
+++ b/frontend/src/components/user-stats/IndexerStatsIncreases.vue
@@ -29,10 +29,14 @@ const postProcessStat = (value: keyof UserProfileScrapedVec) => {
     case 'seed_size':
     case 'uploaded_real':
     case 'downloaded_real':
-      result = bytesToReadable(result)
+      return bytesToReadable(result)
       break
   }
-  return result
+
+  if (Number.isInteger(result)) {
+    return result
+  }
+  return parseFloat(result).toFixed(2)
 }
 </script>
 <style scoped>

--- a/frontend/src/components/user-stats/SearchForm.vue
+++ b/frontend/src/components/user-stats/SearchForm.vue
@@ -19,6 +19,7 @@
       @update:modelValue="(val) => emit('selectedValuesUpdated', val)"
       filter
       display="chip"
+      :optionLabel="titleCase"
       placeholder="Charts to display"
     />
   </div>
@@ -31,6 +32,7 @@ import { getUserStats, type GetUserStatsQuery, type UserProfileScrapedVec, type 
 import { DatePicker, Select, MultiSelect, Button } from 'primevue'
 import { onMounted, ref } from 'vue'
 import { startOfMonth, endOfMonth } from 'date-fns'
+import { titleCase } from 'text-title-case'
 import { getIndexersEnriched, type IndexerEnriched } from '@/services/api/indexerService'
 import { showToast } from '@/main'
 


### PR DESCRIPTION
- Add a heading for each chart instead of relying on the chart legend
- Display the stats in title case
- Round the rest of the stats to 2 decimal points

I have a few other ideas for the frontend such as per-indexer saved defaultSelectedValues and a theme switcher. Would you be open to those?

<img width="2638" height="2272" alt="screenshot 2025-12-22 at 21 59 36@2x" src="https://github.com/user-attachments/assets/30c570a5-afc4-4223-85eb-95ea67a1822a" />
