### PR TITLE
Remove DB port export

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,8 +6,6 @@ services:
     shm_size: 128mb
     volumes:
       - db_data:/var/lib/postgresql/
-    ports:
-      - 5432:5432
     env_file:
       - .env
     healthcheck:


### PR DESCRIPTION
There is no need to export the DB port; the app can connect regardless, and other users on the same host should not have access by default.